### PR TITLE
Add alpha craft stuff to vendor buy lists

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -38,5 +38,6 @@
 		<li>sarg.alphacrafts</li>
 		<li>DankPyon.Medieval.Overhaul.House.Roxmont</li>
 		<li>xrushha.EldersFaction</li>
+		<li>OskarPotocki.VFE.Classical</li>
 	</loadAfter>
 </ModMetaData>

--- a/About/About.xml
+++ b/About/About.xml
@@ -35,5 +35,8 @@
 		<li>OskarPotocki.VFE.Medieval2</li>
 		<li>VE.VanillaChristmasExpanded</li>
 		<li>oskarpotocki.vanillavehiclesexpanded</li>
+		<li>sarg.alphacrafts</li>
+		<li>DankPyon.Medieval.Overhaul.House.Roxmont</li>
+		<li>xrushha.EldersFaction</li>
 	</loadAfter>
 </ModMetaData>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -13,5 +13,6 @@
     <li IfModActive="kentington.saveourship2">Mods and Shit/SOS2</li>
     <li IfModActive="VE.VanillaChristmasExpanded">Mods and Shit/VE Christmas</li>
     <li IfModActive="oskarpotocki.vanillavehiclesexpanded">Mods and Shit/VE Vehicles</li>
+    <li IfModActive="sarg.alphacrafts">Mods and Shit/Alpha Crafts</li>
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/Alpha Crafts/Patches/alpha crafts patch.xml
+++ b/Mods and Shit/Alpha Crafts/Patches/alpha crafts patch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<!-- Add to tribals -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/TraderKindDef[defName="Base_Neolithic_Standard" or
+					defName="Caravan_Neolithic_BulkGoods" or
+					defName="Caravan_Neolithic_ShamanMerchant"]/stockGenerators</xpath>
+				<value>
+					<li Class="AlphaCrafts.StockGenerator_BuyCategory">
+						<category>AC_ArtisanProducts</category>
+					</li>
+				</value>
+			</li>
+
+			<!-- Add to medieval factions -->
+			<li MayRequire="Dankpyon.Medieval.Overhaul" Class="PatchOperationAdd">
+				<xpath>/Defs/TraderKindDef[defName="DankPyon_Base_Medieval_Standard" or
+					defName="DankPyon_Caravan_Medieval_BulkGoodsMerchant" or
+					defName="DankPyon_Caravan_Medieval_BulkGoodsMerchant_Soren" or
+					defName="DankPyon_Visitor_Medieval_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="AlphaCrafts.StockGenerator_BuyCategory">
+						<category>AC_ArtisanProducts</category>
+					</li>
+				</value>
+			</li>
+
+			<!-- Add to roxmont faction -->
+			<li MayRequire="DankPyon.Medieval.Overhaul.House.Roxmont" Class="PatchOperationAdd">
+				<xpath>/Defs/TraderKindDef[defName="DankPyon_Base_Medieval_Roxmont" or
+					defName="DankPyon_Caravan_Medieval_BulkGoodsMerchant_Roxmont" or
+					defName="DankPyon_Visitor_Medieval_Roxmont"]/stockGenerators</xpath>
+				<value>
+					<li Class="AlphaCrafts.StockGenerator_BuyCategory">
+						<category>AC_ArtisanProducts</category>
+					</li>
+				</value>
+			</li>
+
+			<!-- Add to elders faction -->
+			<li MayRequire="xrushha.EldersFaction" Class="PatchOperationAdd">
+				<xpath>/Defs/TraderKindDef[defName="Base_Elders_Standard" or
+					defName="Caravan_Elders_BulkGoods" or defName="Caravan_Elders_ShamanMerchant" or
+					defName="Visitor_Elders_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="AlphaCrafts.StockGenerator_BuyCategory">
+						<category>AC_ArtisanProducts</category>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Mods and Shit/Alpha Crafts/Patches/alpha crafts patch.xml
+++ b/Mods and Shit/Alpha Crafts/Patches/alpha crafts patch.xml
@@ -51,6 +51,17 @@
 					</li>
 				</value>
 			</li>
+
+			<!-- Add to VE classical factions -->
+			<li MayRequire="OskarPotocki.VFE.Classical" Class="PatchOperationAdd">
+				<xpath>/Defs/TraderKindDef[defName="VFEC_Base_Republic_Standard" or
+					defName="VFEC_Caravan_Republic_BulkGoods"]/stockGenerators</xpath>
+				<value>
+					<li Class="AlphaCrafts.StockGenerator_BuyCategory">
+						<category>AC_ArtisanProducts</category>
+					</li>
+				</value>
+			</li>
 		</operations>
 	</Operation>
 </Patch>


### PR DESCRIPTION
Adding to:
* Vanilla Tribal factions (including those descended like Roo's)
* Medieval Overhaul's factions
* Roxmont's additional MO faction
* Elders faction

Note:
* Only adding to bases, bulk good, and shaman vendors.
* Not adding to slavers, weapon vendors, etc.